### PR TITLE
Update libsyntax api to work with nightly 1.38

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -104,7 +104,7 @@ impl Service for Instance {
     type Request = Request;
     type Response = Response;
     type Error = Error;
-    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error>>;
 
     fn call(&self, req: Request) -> Self::Future {
         let uri = req.uri().clone();


### PR DESCRIPTION
Updated so it works with Rust nightly 1.38.
This depends on a pull request for rustdoc-highlight. 
https://github.com/nrc/rustdoc-highlight/pull/9
This fixes #256 